### PR TITLE
fix: Products responsive layout, clamp() title, and button flex

### DIFF
--- a/src/components/features/Products.css
+++ b/src/components/features/Products.css
@@ -46,7 +46,7 @@
 }
 
 .product-title {
-	font-size: 3.6rem;
+	font-size: clamp(1.5rem, 5vw, 3.6rem);
 	font-weight: 700;
 	text-transform: uppercase;
 	text-align: left;
@@ -64,14 +64,14 @@
 .available-now-product-buttons {
 	display: flex;
 	justify-content: space-between;
-	gap: 1.5rem;
+	gap: 0.5rem;
 	flex-wrap: wrap;
 }
 
 .in-development-product-buttons {
 	display: flex;
-	justify-content: end;
-	gap: 1.5rem;
+	justify-content: flex-end;
+	gap: 0.5rem;
 	flex-wrap: wrap;
 }
 
@@ -114,14 +114,16 @@
 #product-availability-button {
 	background-color: #25c115;
 	border: none;
-	width: 60%;
+	flex: 1;
+	min-width: 120px;
 	cursor: pointer !important;
 }
 
 #product-how-to-play-button {
 	background-color: #1586e1;
 	border: none;
-	width: 35%;
+	flex: 1;
+	min-width: 120px;
 	cursor: pointer !important;
 }
 
@@ -129,7 +131,8 @@
 	background-color: #f7b600;
 	color: #f9f9f9;
 	border: none;
-	width: 60%;
+	flex: 1;
+	min-width: 120px;
 	cursor: pointer !important;
 }
 
@@ -143,4 +146,24 @@
 
 #product-in-development-button:hover {
 	background-color: #d89f00; /* darker golden yellow */
+}
+
+@media (max-width: 768px) {
+	.product-section {
+		padding: 1rem;
+	}
+
+	.product-image {
+		max-width: 100%;
+		height: auto;
+	}
+}
+
+@media (max-width: 480px) {
+	#product-availability-button,
+	#product-how-to-play-button,
+	#product-in-development-button {
+		width: 100%;
+		flex: none;
+	}
 }


### PR DESCRIPTION
## Summary
- Applies `clamp(1.5rem, 5vw, 3.6rem)` to `.product-title` font size so the heading scales smoothly from 24px on mobile up to 57.6px on desktop
- Replaces asymmetric `width: 60%` / `width: 35%` button rules with `flex: 1; min-width: 120px` so all product action buttons share space evenly at any width
- Fixes `justify-content: end` (non-standard) → `justify-content: flex-end` on `.in-development-product-buttons`
- Adds `@media (max-width: 768px)` rule reducing `.product-section` padding to `1rem` and clamping `.product-image` to `max-width: 100%; height: auto`
- Adds `@media (max-width: 480px)` rule that sets buttons to `width: 100%; flex: none` so they stack full-width on small phones

## Test plan
- [ ] Build passes: `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build` exits 0
- [ ] At 1280px: product title is large (up to 3.6rem), buttons sit side-by-side with equal widths
- [ ] At 768px: section padding reduces to 1rem, image/text stacks vertically, image does not overflow
- [ ] At 375px: buttons stack full-width, title scales down to minimum 1.5rem (24px), no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)