### PR TITLE
fix: Footer mobile stacking and NaviBar touch target

### DIFF
--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -13,7 +13,7 @@
 }
 
 #footer-center{
-    font-size: small;
+    font-size: 0.875rem;
     align-items: center;
 }
 #footer--right {
@@ -46,4 +46,27 @@
 
 #modal-title {
     color: red;
+}
+
+/* ── Mobile: stack footer columns ── */
+@media (max-width: 768px) {
+    #footer--left,
+    #footer-center,
+    #footer--right {
+        width: 100%;
+        text-align: center;
+        justify-content: center;
+        margin-bottom: 1.5rem;
+    }
+
+    /* Remove extra bottom margin from last column */
+    #footer--right {
+        margin-bottom: 0;
+    }
+
+    /* Social icon size on mobile */
+    #footer--right a svg {
+        width: 24px;
+        height: 24px;
+    }
 }

--- a/src/components/layout/NaviBar.css
+++ b/src/components/layout/NaviBar.css
@@ -24,5 +24,7 @@
 		display: block;
 		margin: 0 auto;
 		text-align: center;
+		min-height: 44px;
+		padding: 0.5rem 1rem;
 	}
 }


### PR DESCRIPTION
## Summary
- Footer columns stack to single column on mobile (≤768px) with centered content
- `font-size: small` replaced with `font-size: 0.875rem` in footer center column
- Social icons resize from 30px desktop to 24px on mobile via SVG CSS rule
- NaviBar shop button gets `min-height: 44px; padding: 0.5rem 1rem` for 44px minimum touch target on mobile

## Test plan
- [ ] Verify footer stacks to single column at 375px (mobile)
- [ ] Verify footer shows 3 columns side-by-side at 1280px (desktop)
- [ ] Verify footer columns are centered at 768px (tablet, boundary)
- [ ] Verify social icons appear smaller (24px) on mobile vs desktop (30px)
- [ ] Verify Shop button in navbar has at least 44px tap height when navbar is collapsed on mobile
- [ ] Run `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build` — must exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)