### PR TITLE
fix: World page responsive layout and clamp() typography

### DIFF
--- a/src/components/features/World.css
+++ b/src/components/features/World.css
@@ -64,5 +64,5 @@
 	text-transform: uppercase !important;
 	text-align: left !important;
 	font-family: "Poppins", sans-serif !important;
-	margin-bottom: 1rem !important;
+	margin-bottom: 0 !important;
 }

--- a/src/components/features/World.css
+++ b/src/components/features/World.css
@@ -32,7 +32,7 @@
 
 .world--map--button {
 	position: absolute;
-	top: 100px;
+	top: 2rem;
 	left: 50%;
 	transform: translateX(-50%);
 	z-index: 10;
@@ -59,7 +59,7 @@
 }
 
 .world-modal-title {
-	font-size: 3.6rem !important;
+	font-size: clamp(1.75rem, 5vw, 3.6rem) !important;
 	font-weight: 700 !important;
 	text-transform: uppercase !important;
 	text-align: left !important;

--- a/src/components/features/World.js
+++ b/src/components/features/World.js
@@ -19,7 +19,7 @@ const World = () => {
 			>
 				Learn More
 			</Button>
-			<Modal show={showModal} onHide={handleCloseModal} size="lg">
+			<Modal show={showModal} onHide={handleCloseModal} size="lg" centered scrollable>
 				<Modal.Header closeButton>
 					<Modal.Title className="world-modal-title">
 						The World of Moratia

--- a/src/components/game-info/Races.css
+++ b/src/components/game-info/Races.css
@@ -11,28 +11,36 @@
 }
 
 #race-right {
-	padding: 5% 15% 5% 9%;
+	padding: 5%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 }
 
 #race-left {
-	padding: 5% 15% 5% 20%;
+	padding: 5%;
 	display: flex;
 	justify-content: center;
 }
 
 #race-image {
-	height: 75vmin;
+	max-height: 60vmin;
+	height: auto;
 }
 
 #races-title {
-	font-size: 3.6rem;
+	font-size: clamp(1.75rem, 5vw, 3.6rem);
 	font-weight: 700;
 	text-transform: uppercase;
 	text-align: center;
 	font-family: "Poppins", sans-serif;
 	margin-top: 1rem;
+}
+
+@media (max-width: 768px) {
+	#race-right,
+	#race-left {
+		padding: 1rem;
+	}
 }
 

--- a/src/components/game-info/RacesSlider.css
+++ b/src/components/game-info/RacesSlider.css
@@ -7,7 +7,7 @@
 .swiper-slide {
 	background-position: center;
 	background-size: cover;
-	width: 300px;
+	width: clamp(200px, 80vw, 300px);
 	height: auto;
 }
 

--- a/src/components/game-info/WorldText.css
+++ b/src/components/game-info/WorldText.css
@@ -7,6 +7,8 @@
 #world--text-box {
 	overflow-y: scroll;
 	padding-right: 10px;
+	scrollbar-width: thin;
+	scrollbar-color: #f9f9f9 transparent;
 }
 
 #world--headers-text {
@@ -49,4 +51,10 @@
 /* Handle on hover */
 #world--text-box::-webkit-scrollbar-thumb:hover {
 	background: #bababa;
+}
+
+@media (max-width: 768px) {
+	#world--text-box {
+		max-height: 50vh;
+	}
 }


### PR DESCRIPTION
## Summary
- Replaces fixed `3.6rem` font sizes on modal title and Races heading with `clamp(1.75rem, 5vw, 3.6rem)` for smooth mobile scaling
- Changes `.world--map--button` `top` from `100px` to `2rem` and ensures `white-space: nowrap`
- Adds Firefox scrollbar fallback (`scrollbar-width: thin; scrollbar-color`) and a `max-height: 50vh` media query for the WorldText scrollable box on mobile
- Normalizes asymmetric Races padding (`5% 9%/15%/20%`) to uniform `5%` with a `1rem` mobile override; fixes race image from `height: 75vmin` to `max-height: 60vmin; height: auto`
- Changes RacesSlider `.swiper-slide` from fixed `width: 300px` to `clamp(200px, 80vw, 300px)` for responsive sizing

## Test plan
- [ ] Build passes: `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build` exits 0
- [ ] At 375px: modal title fits on one line, no horizontal overflow
- [ ] At 768px: Races title scales fluidly, slider slides don't overflow
- [ ] At 1280px: all elements render at full intended size
- [ ] Firefox: scrollbar in WorldText modal uses thin native style
- [ ] Race images no longer overflow their containers at large viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)