### PR TITLE
fix: FeaturedProduct mobile layout and clamp() fonts

### DIFF
--- a/src/components/featured-product/FeaturedProduct.css
+++ b/src/components/featured-product/FeaturedProduct.css
@@ -7,7 +7,6 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-height: 100vh;
 }
 
 .featured-product__container {
@@ -51,7 +50,7 @@
 }
 
 .featured-product__subtitle {
-	font-size: 2.5rem;
+	font-size: clamp(1.5rem, 4vw, 3rem);
 	font-weight: bold;
 	color: #212529;
 	margin-bottom: 1.5rem;
@@ -105,6 +104,12 @@
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+@media (min-width: 992px) {
+	.featured-product {
+		min-height: 100vh;
+	}
+}
+
 @media (max-width: 991.98px) {
 	.featured-product__container {
 		flex-direction: column;
@@ -114,11 +119,31 @@
 		margin-bottom: 2rem;
 	}
 
+	.featured-product__image {
+		max-width: 100%;
+		height: auto;
+	}
+
 	.featured-product__content {
 		text-align: center;
 	}
 
 	.featured-product__features li {
 		text-align: left;
+	}
+}
+
+@media (max-width: 768px) {
+	.featured-product__content {
+		text-align: center;
+	}
+
+	.featured-product__cta {
+		width: 100%;
+	}
+
+	.featured-product__image {
+		max-width: 100%;
+		height: auto;
 	}
 }


### PR DESCRIPTION
Ensures column stacking on mobile, full-width CTA button, removes min-height: 100vh from mobile, applies clamp() font sizes.

## Summary
- Moved `min-height: 100vh` from base rule to `@media (min-width: 992px)` so it only applies on desktop
- Applied `clamp(1.5rem, 4vw, 3rem)` to `.featured-product__subtitle` (was hardcoded `2.5rem`)
- Added `@media (max-width: 768px)` block: full-width CTA button (`width: 100%`), centered text, `height: auto` on image
- Added `height: auto` + `max-width: 100%` to `.featured-product__image` within the existing `@media (max-width: 991.98px)` block to prevent image collapse at tablet widths in column layout

## Test plan
- [ ] Build passes: `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build`
- [ ] On mobile (375px): image stacks above text, text is centered, CTA button is full-width
- [ ] On tablet (768px): same column stacking, no image collapse
- [ ] On desktop (1280px): min-height 100vh active, side-by-side layout, subtitle scales with viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)