### PR TITLE
fix: ContactForm, ContactUs, and AboutUs responsive CSS

### DIFF
--- a/src/components/features/AboutUs.css
+++ b/src/components/features/AboutUs.css
@@ -44,5 +44,16 @@
         max-height: none;
         overflow-y: visible;
         text-align: center;
+        padding: 1rem;
+    }
+
+    #about-us--left {
+        padding: 1rem;
+    }
+
+    #about-us--image {
+        width: 100%;
+        height: auto;
+        max-height: none;
     }
 }

--- a/src/components/features/AboutUs.css
+++ b/src/components/features/AboutUs.css
@@ -12,7 +12,7 @@
 
 #about-us--title{
     text-transform: uppercase;
-    
+
 }
 #about-us--right {
     padding: 5%;
@@ -20,7 +20,7 @@
     flex-direction: column;
     justify-content: center;
     overflow-y: scroll;
-    /* height: 400px; */
+    max-height: 60vh;
 }
 
 #about-us--left {
@@ -31,9 +31,18 @@
 }
 
 #about-us--image {
-    height: 40vmin;
+    max-height: 40vmin;
+    height: auto;
 }
 
-.image-size{
-    size: 25%;
+@media (max-width: 768px) {
+    #about-us .row {
+        flex-direction: column;
+    }
+
+    #about-us--right {
+        max-height: none;
+        overflow-y: visible;
+        text-align: center;
+    }
 }

--- a/src/components/marketing/ContactForm.css
+++ b/src/components/marketing/ContactForm.css
@@ -52,15 +52,23 @@
 }
 
 .form-group {
-	font-size: 1.6rem;
+	font-size: 1rem;
 	text-align: left;
 }
 
-#captcha {
+.recaptcha-container {
+	display: flex;
+	justify-content: center;
 	margin-bottom: 1rem;
-	justify-self: center;
 }
 
 .reset-button {
-	width: 20vw;
+	width: auto;
+	min-width: 120px;
+}
+
+@media (max-width: 768px) {
+	.contact-form {
+		padding: 1rem;
+	}
 }

--- a/src/components/marketing/ContactForm.css
+++ b/src/components/marketing/ContactForm.css
@@ -43,7 +43,7 @@
 }
 
 #contact-form-title {
-	font-size: 3.6rem;
+	font-size: clamp(1.5rem, 4vw, 3rem);
 	font-weight: 700;
 	text-transform: uppercase;
 	text-align: center;

--- a/src/components/marketing/ContactUs.css
+++ b/src/components/marketing/ContactUs.css
@@ -4,8 +4,14 @@
 	background-position: top;
 	background-repeat: no-repeat;
 	color: #f9f9ff;
-	height: 100vh;
+	min-height: 100vh;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+}
+
+@media (max-width: 768px) {
+	#contact-us {
+		padding: 1rem;
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes oversized form label font (1.6rem → 1rem) in ContactForm
- Replaces broken `justify-self: center` on reCAPTCHA with `.recaptcha-container { display: flex; justify-content: center }` for actual centering
- Fixes vw-based reset button width (`20vw` → `width: auto; min-width: 120px`)
- Fixes `height: 100vh` → `min-height: 100vh` in ContactUs so tall content isn't clipped
- Removes invalid CSS `size: 25%` property from `.image-size` in AboutUs
- Adds `max-height: 60vh` to `#about-us--right` so `overflow-y: scroll` has a bound to work against
- Fixes image sizing: `height: 40vmin` → `max-height: 40vmin; height: auto` to prevent squishing
- Adds mobile (`≤768px`) column stacking for About content with `text-align: center`
- Adds mobile responsive padding to ContactForm and ContactUs

## Test plan
- [ ] Build passes: `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build`
- [ ] Visit `/about` at 375px — About columns stack vertically, text centered
- [ ] Visit `/about` at 768px — Contact form labels are readable (1rem), reCAPTCHA centered
- [ ] Visit `/about` at 1280px — About section shows side-by-side columns with image
- [ ] Verify no `size:` CSS warnings in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)